### PR TITLE
 API Prod Release v1.3.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.1
+current_version = 1.3.2
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # REST API for NBA ELT Project
 ![Tests](https://github.com/jyablonski/nba_elt_rest_api/actions/workflows/test.yml/badge.svg) ![Deployment](https://github.com/jyablonski/nba_elt_rest_api/actions/workflows/deploy.yml/badge.svg) ![Code Style](https://img.shields.io/badge/code%20style-black-000000.svg)
 
-Version: 1.3.1
+Version: 1.3.2
 
 [API](https://api.jyablonski.dev)

--- a/src/routers/past_bets.py
+++ b/src/routers/past_bets.py
@@ -27,9 +27,13 @@ def get_user_past_bets_page(
     user_past_predictions_success_count = user_past_predictions.filter(
         UserPastPredictions.is_correct_prediction == 1
     ).count()
-    user_past_predictions_pct_count = round(
-        user_past_predictions_success_count / user_past_predictions_count, 3
-    )
+    
+    if user_past_predictions_count == 0:
+        user_past_predictions_pct_count = 0
+    else:
+        user_past_predictions_pct_count = round(
+            user_past_predictions_success_count / user_past_predictions_count, 3
+        )
 
     return templates.TemplateResponse(
         "past_bets.html",

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,7 +18,7 @@
     {% endblock %}
     <nav class="navfoot">
         <div style="position: absolute; bottom: 0; left: 0; width: 100%; text-align: center;">
-            &copy; 2023 | <a href="/">Home</a> | Version: 1.3.1
+            &copy; 2023 | <a href="/">Home</a> | Version: 1.3.2
         </div>
     </nav>
 


### PR DESCRIPTION
- Fixing issue with `past_bets` endpoint that was getting a division by zero error when a user has never made any predictions before.