### PR TITLE
API Prod Release v1.4.6

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.5
+current_version = 1.4.6
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,5 +15,5 @@ dependencies:
 - requirements.txt
 
 frontend:
-- static/*
-- templates/*
+- any: ['static/*', 'templates/*']
+  all: ['!templates/base.html']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,6 +14,8 @@ dependencies:
 - Pipfile
 - requirements.txt
 
+# any file in static or templates
+# but if the only change is in base.html, then no label
 frontend:
 - any: ['static/*', 'templates/*']
   all: ['!templates/base.html']

--- a/README.md
+++ b/README.md
@@ -3,10 +3,29 @@
 
 Version: 1.4.5
 
+## [API](https://api.jyablonski.dev)
+
+The REST API has the following functionalities:
+- Serves Data built from the NBA ELT Pipeline through various endpoints
+- Allows Users to login & make NBA Game Win Predictions starting from the [Login Web Page](https://api.jyablonski.dev/login)
+- Hosts an Internal Admin Site w/ the following Pages:
+  -  Page to flip Feature Flags on / off that are used in the project.
+  -  Page to create incidents which will automatically popup on the Web Dashboard to alert users of any missing or out-of-data data issues.
+
+## Running The App
+Clone the Repo & run `make up` which spins up the App locally [here](http://localhost:8080/) using 2 Docker Containers:
+- Postgres Database
+- FastAPI Server
+
+When finished run `make down`.
+
+## Tests
+All Tests are ran after every Commit on a PR via GitHub Actions.  
+
+To run tests locally, run `make test`.
+
 ## Project
 ![NBA ELT Pipeline Data Flow 2](https://github.com/jyablonski/nba_elt_rest_api/assets/16946556/67fd15c7-7fed-43cc-a3b8-0e267ca968b3)
-
-## [API](https://api.jyablonski.dev)
 
 1. Links to other Repos providing infrastructure for this Project
     * [Shiny Server](https://github.com/jyablonski/NBA-Dashboard)

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Version: 1.4.6
 ## [API](https://api.jyablonski.dev)
 
 The REST API has the following functionalities:
-- Serves Data built from the NBA ELT Pipeline through various endpoints
+- Serves Data built from the NBA ELT Pipeline through various GET endpoints
 - Allows Users to login & make NBA Game Win Predictions starting from the [Login Web Page](https://api.jyablonski.dev/login)
 - Hosts an Internal Admin Site w/ the following Pages:
-  -  Page to flip Feature Flags on / off that are used in the project.
+  -  Page to flip Feature Flags on / off that are used in various components throughout the Project.
   -  Page to create incidents which will automatically popup on the Web Dashboard to alert users of any missing or out-of-data data issues.
 
 ## Running The App
-Clone the Repo & run `make up` which spins up the App locally [here](http://localhost:8080/) using 2 Docker Containers:
+Clone the Repo & run `make up` which spins up the App locally served [here](http://localhost:8080/) using 2 Docker Containers:
 - Postgres Database
 - FastAPI Server
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Clone the Repo & run `make up` which spins up the App locally served [here](http
 When finished run `make down`.
 
 ## Tests
-All Tests are ran after every Commit on a PR via GitHub Actions.  
-
 To run tests locally, run `make test`.
+
+The same Test Suite is ran after every commit on a PR via GitHub Actions.
 
 ## Project
 ![NBA ELT Pipeline Data Flow 2](https://github.com/jyablonski/nba_elt_rest_api/assets/16946556/67fd15c7-7fed-43cc-a3b8-0e267ca968b3)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The REST API has the following functionalities:
 - Allows Users to login & make NBA Game Win Predictions starting from the [Login Web Page](https://api.jyablonski.dev/login)
 - Hosts an Internal Admin Site w/ the following Pages:
   -  Page to flip Feature Flags on / off that are used in various components throughout the Project.
-  -  Page to create incidents which will automatically popup on the Web Dashboard to alert users of any missing or out-of-data data issues.
+  -  Page to create incidents which will automatically popup on the Web Dashboard to alert users of any missing or out-of-date data issues.
 
 ## Running The App
 Clone the Repo & run `make up` which spins up the App locally served [here](http://localhost:8080/) using 2 Docker Containers:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # REST API for NBA ELT Project
 ![Tests](https://github.com/jyablonski/nba_elt_rest_api/actions/workflows/test.yml/badge.svg) ![Deployment](https://github.com/jyablonski/nba_elt_rest_api/actions/workflows/deploy.yml/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/jyablonski/nba_elt_rest_api/badge.svg?branch=master)](https://coveralls.io/github/jyablonski/nba_elt_rest_api?branch=master) ![Code Style](https://img.shields.io/badge/code%20style-black-000000.svg)
 
-Version: 1.4.5
+Version: 1.4.6
 
 ## [API](https://api.jyablonski.dev)
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ To run tests locally, run `make test`.
 
 The same Test Suite is ran after every commit on a PR via GitHub Actions.
 
+## Contributing
+Please be sure that all PRs are Squash Merged into `master`
+
+To bump the Repo, run `make bump-patch` (or `make bump-minor` / `make bump-major`) which bumps the Version Number in `.bumpversion.cfg` as well as `templates/base.html`.
+
 ## Project
 ![NBA ELT Pipeline Data Flow 2](https://github.com/jyablonski/nba_elt_rest_api/assets/16946556/67fd15c7-7fed-43cc-a3b8-0e267ca968b3)
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,7 +20,7 @@
         <div style="text-align:center;">
             &copy; 2023
             <a href="/" class="home"><img id="home" src="{{ url_for('static', path='/home.png') }}"></a>
-            Version: 1.4.5
+            Version: 1.4.6
         </div>
     </nav>
 


### PR DESCRIPTION
### Description
Updated Documentation

## Added
- None

## Updated
- `README.md` File for new documentation
- `.github/labeler.yml` so a `frontend` tag isn't put on every PR because the Repo was bumped

## Deleted
- None