### PR TITLE
API Prod Release v1.8.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.7.8
+current_version = 1.8.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # REST API for NBA ELT Project
 ![Tests](https://github.com/jyablonski/nba_elt_rest_api/actions/workflows/test.yaml/badge.svg) ![Deployment](https://github.com/jyablonski/nba_elt_rest_api/actions/workflows/deploy.yaml/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/jyablonski/nba_elt_rest_api/badge.svg?branch=master)](https://coveralls.io/github/jyablonski/nba_elt_rest_api?branch=master) ![Code Style](https://img.shields.io/badge/code%20style-black-000000.svg)
 
-Version: 1.7.8
+Version: 1.8.0
 
 ## [API](https://api.jyablonski.dev)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Clone the Repo & run `make up` which spins up the App locally served [here](http
 - Postgres Database
 - FastAPI Server
 
-If you wish to login to a User locally with bootstrapped data ready to go, a set of Credentials are listed below:
+To Login to the App locally, a set of Credentials for an Admin User are listed below:
 - Username: `test1`
 - Password: `password`
 

--- a/docker/postgres_bootstrap.sql
+++ b/docker/postgres_bootstrap.sql
@@ -1908,7 +1908,7 @@ CREATE TABLE IF NOT EXISTS rest_api_users
 INSERT INTO rest_api_users(username, password, salt, email, role)
 VALUES ('jyablonski', 'db15bf237233df6654f39476884e8bb9', 'eylptjzw6tqy68zxg5b8v9l2bdwxsztf', 'j@yablonski.com', 'Admin'),
        ('test', '0b1bcb3aa21cc0325ccfec50ae77ee09', 'utwvsvfcofpanwtwt7u3tegwvnz5ey35', 'test@nobody.com', 'Consumer'),
-       ('test1', 'fc69b839fbcd8ecd2d9407406a9eec66', 'u61hred56dm6il2sgtws9m1k4704y3ph', 'test@nobody.com', 'Consumer'),
+       ('test1', 'fc69b839fbcd8ecd2d9407406a9eec66', 'u61hred56dm6il2sgtws9m1k4704y3ph', 'test@nobody.com', 'Admin'),
        ('test2', '32b67f6dad97c4d009bab26dfbafbe27', 'cxfpyjvny5kro6phuxpchxlxg1c1stjw', 'test@nobody.com', 'Consumer'),
        ('test3', '6c4dab6f6c721e9eb0ed908e8b7f7a06', 'lv1exd0c2tmfv414voo1716ggrpnk60f', 'test@nobody.com', 'Consumer');
 

--- a/docker/postgres_bootstrap.sql
+++ b/docker/postgres_bootstrap.sql
@@ -1899,16 +1899,18 @@ CREATE TABLE IF NOT EXISTS rest_api_users
     password text not null,
     email text,
     salt text,
-    created_at timestamp default now()
+	role varchar default 'Consumer',
+    created_at timestamp default now(),
+	modified_at timestamp default now()
 );
 
 -- these users all have password as the actual "password"
-INSERT INTO rest_api_users(username, password, salt, email)
-VALUES ('jyablonski', 'db15bf237233df6654f39476884e8bb9', 'eylptjzw6tqy68zxg5b8v9l2bdwxsztf', 'j@yablonski.com'),
-       ('test', '0b1bcb3aa21cc0325ccfec50ae77ee09', 'utwvsvfcofpanwtwt7u3tegwvnz5ey35', 'test@nobody.com'),
-       ('test1', 'fc69b839fbcd8ecd2d9407406a9eec66', 'u61hred56dm6il2sgtws9m1k4704y3ph', 'test@nobody.com'),
-       ('test2', '32b67f6dad97c4d009bab26dfbafbe27', 'cxfpyjvny5kro6phuxpchxlxg1c1stjw', 'test@nobody.com'),
-       ('test3', '6c4dab6f6c721e9eb0ed908e8b7f7a06', 'lv1exd0c2tmfv414voo1716ggrpnk60f', 'test@nobody.com');
+INSERT INTO rest_api_users(username, password, salt, email, role)
+VALUES ('jyablonski', 'db15bf237233df6654f39476884e8bb9', 'eylptjzw6tqy68zxg5b8v9l2bdwxsztf', 'j@yablonski.com', 'Admin'),
+       ('test', '0b1bcb3aa21cc0325ccfec50ae77ee09', 'utwvsvfcofpanwtwt7u3tegwvnz5ey35', 'test@nobody.com', 'Consumer'),
+       ('test1', 'fc69b839fbcd8ecd2d9407406a9eec66', 'u61hred56dm6il2sgtws9m1k4704y3ph', 'test@nobody.com', 'Consumer'),
+       ('test2', '32b67f6dad97c4d009bab26dfbafbe27', 'cxfpyjvny5kro6phuxpchxlxg1c1stjw', 'test@nobody.com', 'Consumer'),
+       ('test3', '6c4dab6f6c721e9eb0ed908e8b7f7a06', 'lv1exd0c2tmfv414voo1716ggrpnk60f', 'test@nobody.com', 'Consumer');
 
 
 DROP TABLE IF EXISTS user_predictions;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nba-elt-rest-api"
-version = "1.7.8"
+version = "1.8.0"
 description = "REST API Project"
 authors = ["jyablonski9 <jyablonski9@gmail.com>"]
 readme = "README.md"

--- a/src/models.py
+++ b/src/models.py
@@ -7,6 +7,7 @@ from sqlalchemy import (
     PrimaryKeyConstraint,
     TIMESTAMP,
 )
+from sqlalchemy.sql import func
 
 from src.database import Base
 
@@ -194,7 +195,9 @@ class Users(Base):
     password = Column(String, nullable=False)
     email = Column(String, nullable=True)
     salt = Column(String, nullable=False)
-    created_at = Column(TIMESTAMP, nullable=False)
+    created_at = Column(TIMESTAMP, nullable=False, default=func.now())
+    role = Column(String, nullable=False, default="Consumer")
+    modified_at = Column(TIMESTAMP, nullable=False, default=func.now())
 
 
 class UserPastPredictions(Base):

--- a/src/routers/admin.py
+++ b/src/routers/admin.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import HTMLResponse
 
 from src.admin_tasks import invoke_restart_dashboard
-from src.security import get_current_role_from_token
+from src.security import get_current_creds_from_token
 from src.utils import templates
 
 router = APIRouter()
@@ -11,9 +11,9 @@ router = APIRouter()
 @router.get("/admin", response_class=HTMLResponse)
 def get_admin(
     request: Request,
-    role: str = Depends(get_current_role_from_token),
+    creds: str = Depends(get_current_creds_from_token),
 ):
-    if role != "Admin":
+    if creds["role"] != "Admin":
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="You do not have the powa",
@@ -25,9 +25,9 @@ def get_admin(
 @router.post("/invoke_dashboard_restart", response_class=HTMLResponse)
 def post_dashboard_restart(
     request: Request,
-    role: str = Depends(get_current_role_from_token),
+    creds: str = Depends(get_current_creds_from_token),
 ):
-    if role != "Admin":
+    if creds["role"] != "Admin":
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="You do not have the powa",

--- a/src/routers/admin.py
+++ b/src/routers/admin.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import HTMLResponse
 
 from src.admin_tasks import invoke_restart_dashboard
-from src.security import get_current_user_from_token
+from src.security import get_current_role_from_token
 from src.utils import templates
 
 router = APIRouter()
@@ -11,9 +11,9 @@ router = APIRouter()
 @router.get("/admin", response_class=HTMLResponse)
 def get_admin(
     request: Request,
-    username: str = Depends(get_current_user_from_token),
+    role: str = Depends(get_current_role_from_token),
 ):
-    if username != "jyablonski":
+    if role != "Admin":
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="You do not have the powa",
@@ -25,9 +25,9 @@ def get_admin(
 @router.post("/invoke_dashboard_restart", response_class=HTMLResponse)
 def post_dashboard_restart(
     request: Request,
-    username: str = Depends(get_current_user_from_token),
+    role: str = Depends(get_current_role_from_token),
 ):
-    if username != "jyablonski":
+    if role != "Admin":
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="You do not have the powa",

--- a/src/routers/auth.py
+++ b/src/routers/auth.py
@@ -37,7 +37,7 @@ def login_for_access_token(
     # on the token is not > 30 days old
     access_token_expires = datetime.now(timezone.utc) + timedelta(days=30)
     access_token = create_access_token(
-        data={"sub": user.username}, expires=access_token_expires
+        data={"sub": user.username, "role": user.role}, expires=access_token_expires
     )
     response.set_cookie(
         key="access_token",

--- a/src/routers/bets.py
+++ b/src/routers/bets.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 from src.dao.bets import store_bet_predictions
 from src.database import get_db
 from src.models import Predictions, UserPredictions
-from src.security import get_current_user_from_token
+from src.security import get_current_creds_from_token
 from src.utils import templates
 
 router = APIRouter()
@@ -17,9 +17,11 @@ router = APIRouter()
 @router.get("/bets", response_class=HTMLResponse)
 async def get_user_bets_page(
     request: Request,
-    username: str = Depends(get_current_user_from_token),
+    creds: str = Depends(get_current_creds_from_token),
     db: Session = Depends(get_db),
 ):
+    username = creds["username"]
+
     if username is None:
         # Redirect to the /login endpoint
         return RedirectResponse("/login")
@@ -70,11 +72,12 @@ async def get_user_bets_page(
 @router.post("/bets")
 def store_user_bets_predictions_from_ui(
     request: Request,
-    username: str = Depends(get_current_user_from_token),
+    creds: str = Depends(get_current_creds_from_token),
     bet_predictions: List[str] = Form(...),
     bet_amounts: List[int] = Form(...),
     db: Session = Depends(get_db),
 ):
+    username = creds["username"]
     # username_check = (db.query(Users).filter(Users.username == username)).first()
 
     # if username_check is None:

--- a/src/routers/feature_flags.py
+++ b/src/routers/feature_flags.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from src.dao.feature_flags import create_feature_flags, update_feature_flags
 from src.database import get_db
 from src.models import FeatureFlags
-from src.security import get_current_user_from_token
+from src.security import get_current_creds_from_token
 from src.utils import templates
 
 router = APIRouter()
@@ -16,10 +16,10 @@ router = APIRouter()
 @router.get("/admin/feature_flags", response_class=HTMLResponse)
 def get_feature_flags(
     request: Request,
-    username: str = Depends(get_current_user_from_token),
+    creds: str = Depends(get_current_creds_from_token),
     db: Session = Depends(get_db),
 ):
-    if username != "jyablonski":
+    if creds["role"] != "Admin":
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You do not have the powa",
@@ -36,10 +36,10 @@ def get_feature_flags(
 def post_feature_flags(
     request: Request,
     feature_flag_list: List[str] = Form(...),
-    username: str = Depends(get_current_user_from_token),
+    creds: str = Depends(get_current_creds_from_token),
     db: Session = Depends(get_db),
 ):
-    if username != "jyablonski":
+    if creds["role"] != "Admin":
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You do not have the powa",
@@ -57,10 +57,10 @@ def post_feature_flags(  # noqa: F811
     request: Request,
     feature_flag_name_form: str = Form(...),
     feature_flag_is_enabled_form: int = Form(...),
-    username: str = Depends(get_current_user_from_token),
+    creds: str = Depends(get_current_creds_from_token),
     db: Session = Depends(get_db),
 ):
-    if username != "jyablonski":
+    if creds["role"] != "Admin":
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You do not have the powa",

--- a/src/routers/incidents.py
+++ b/src/routers/incidents.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from src.dao.incidents import create_incident, update_incident
 from src.database import get_db
 from src.models import Incidents
-from src.security import get_current_user_from_token
+from src.security import get_current_creds_from_token
 from src.utils import templates
 
 router = APIRouter()
@@ -16,10 +16,10 @@ router = APIRouter()
 @router.get("/admin/incidents", response_class=HTMLResponse)
 def get_incidents(
     request: Request,
-    username: str = Depends(get_current_user_from_token),
+    creds: str = Depends(get_current_creds_from_token),
     db: Session = Depends(get_db),
 ) -> HTMLResponse:
-    if username != "jyablonski":
+    if creds["role"] != "Admin":
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You do not have the powa",
@@ -36,10 +36,10 @@ def get_incidents(
 def post_incidents(
     request: Request,
     incident_list: List[str] = Form(...),
-    username: str = Depends(get_current_user_from_token),
+    creds: str = Depends(get_current_creds_from_token),
     db: Session = Depends(get_db),
 ):
-    if username != "jyablonski":
+    if creds["role"] != "Admin":
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You do not have the powa",
@@ -58,10 +58,10 @@ def post_incidents_create(  # noqa: F811
     incident_name_form: str = Form(...),
     incident_description_form: str = Form(...),
     incident_is_active_form: int = Form(...),
-    username: str = Depends(get_current_user_from_token),
+    creds: str = Depends(get_current_creds_from_token),
     db: Session = Depends(get_db),
 ):
-    if username != "jyablonski":
+    if creds["role"] != "Admin":
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You do not have the powa",

--- a/src/routers/login.py
+++ b/src/routers/login.py
@@ -11,7 +11,7 @@ from src.dao.users import create_user
 from src.database import get_db
 from src.models import Users
 from src.schemas import UserCreate
-from src.security import get_current_user_from_token, LoginForm
+from src.security import get_current_creds_from_token, LoginForm
 from src.utils import templates
 from src.routers.auth import login_for_access_token
 
@@ -21,12 +21,17 @@ router = APIRouter()
 @router.get("/login")
 def login(
     request: Request,
-    username: str = Depends(get_current_user_from_token),
+    creds: str = Depends(get_current_creds_from_token),
 ):
-    if username is not None:
+    if creds is not None:
         return templates.TemplateResponse(
             "login.html",
-            {"request": request, "username": username, "msg": "Login Successful"},
+            {
+                "request": request,
+                "username": creds["username"],
+                "role": creds["role"],
+                "msg": "Login Successful",
+            },
         )
     else:
         return templates.TemplateResponse("login.html", {"request": request})

--- a/src/routers/past_bets.py
+++ b/src/routers/past_bets.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 
 from src.database import get_db
 from src.models import UserPastPredictions
-from src.security import get_current_user_from_token
+from src.security import get_current_creds_from_token
 from src.utils import generate_csv, templates
 
 router = APIRouter()
@@ -16,9 +16,11 @@ router = APIRouter()
 @router.get("/past_bets", response_class=HTMLResponse)
 def get_user_past_bets_page(
     request: Request,
-    username: str = Depends(get_current_user_from_token),
+    creds: str = Depends(get_current_creds_from_token),
     db: Session = Depends(get_db),
 ):
+    username = creds["username"]
+
     user_past_predictions = db.query(UserPastPredictions).filter(
         UserPastPredictions.username == username,
         UserPastPredictions.game_date >= "2023-10-01",
@@ -70,9 +72,11 @@ def get_user_past_bets_page(
 @router.post("/past_bets", response_class=StreamingResponse)
 def post_user_past_bets_page(
     request: Request,
-    username: str = Depends(get_current_user_from_token),
+    creds: str = Depends(get_current_creds_from_token),
     db: Session = Depends(get_db),
 ):
+    username = creds["username"]
+
     user_past_predictions = (
         (db.query(UserPastPredictions))
         .filter(UserPastPredictions.username == username)

--- a/src/security.py
+++ b/src/security.py
@@ -161,7 +161,7 @@ def get_current_creds_from_token(token: str = Depends(oauth2_scheme)) -> str:
             return None
 
         payload = jwt.decode(token, os.environ.get("API_KEY"), algorithms=["HS256"])
-        print(payload)
+
         if payload.get("role") is None or payload.get("sub") is None:
             raise credentials_exception
 

--- a/src/security.py
+++ b/src/security.py
@@ -103,50 +103,50 @@ oauth2_scheme = OAuth2PasswordBearerWithCookie(tokenUrl="token")
 
 # this is the form / web app version to authenticate
 # only difference is `oauth2_scheme` vs `oauth2_scheme_og`
-def get_current_user_from_token(token: str = Depends(oauth2_scheme)) -> str:
-    credentials_exception = HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Could not validate credentials",
-        headers={"WWW-Authenticate": "Bearer"},
-    )
+# def get_current_user_from_token(token: str = Depends(oauth2_scheme)) -> str:
+#     credentials_exception = HTTPException(
+#         status_code=status.HTTP_401_UNAUTHORIZED,
+#         detail="Could not validate credentials",
+#         headers={"WWW-Authenticate": "Bearer"},
+#     )
 
-    try:
-        if token is None:
-            return None
+#     try:
+#         if token is None:
+#             return None
 
-        payload = jwt.decode(token, os.environ.get("API_KEY"), algorithms=["HS256"])
+#         payload = jwt.decode(token, os.environ.get("API_KEY"), algorithms=["HS256"])
 
-        if payload.get("sub") is None:
-            raise credentials_exception
+#         if payload.get("sub") is None:
+#             raise credentials_exception
 
-        return payload.get("sub")
+#         return payload.get("sub")
 
-    except JWTError as e:
-        print(f"JWT Error Occurred, {e}")
-        raise credentials_exception
+#     except JWTError as e:
+#         print(f"JWT Error Occurred, {e}")
+#         raise credentials_exception
 
 
-def get_current_role_from_token(token: str = Depends(oauth2_scheme)) -> str:
-    credentials_exception = HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Could not validate credentials",
-        headers={"WWW-Authenticate": "Bearer"},
-    )
+# def get_current_role_from_token(token: str = Depends(oauth2_scheme)) -> str:
+#     credentials_exception = HTTPException(
+#         status_code=status.HTTP_401_UNAUTHORIZED,
+#         detail="Could not validate credentials",
+#         headers={"WWW-Authenticate": "Bearer"},
+#     )
 
-    try:
-        if token is None:
-            return None
+#     try:
+#         if token is None:
+#             return None
 
-        payload = jwt.decode(token, os.environ.get("API_KEY"), algorithms=["HS256"])
+#         payload = jwt.decode(token, os.environ.get("API_KEY"), algorithms=["HS256"])
 
-        if payload.get("role") is None:
-            raise credentials_exception
+#         if payload.get("role") is None:
+#             raise credentials_exception
 
-        return payload.get("role")
+#         return payload.get("role")
 
-    except JWTError as e:
-        print(f"JWT Error Occurred, {e}")
-        raise credentials_exception
+#     except JWTError as e:
+#         print(f"JWT Error Occurred, {e}")
+#         raise credentials_exception
 
 
 def get_current_creds_from_token(token: str = Depends(oauth2_scheme)) -> str:

--- a/src/security.py
+++ b/src/security.py
@@ -115,12 +115,34 @@ def get_current_user_from_token(token: str = Depends(oauth2_scheme)) -> str:
             return None
 
         payload = jwt.decode(token, os.environ.get("API_KEY"), algorithms=["HS256"])
-        username: str = payload.get("sub")
 
-        if username is None:
+        if payload.get("sub") is None:
             raise credentials_exception
-        else:
-            return username
+
+        return payload.get("sub")
+
+    except JWTError as e:
+        print(f"JWT Error Occurred, {e}")
+        raise credentials_exception
+
+
+def get_current_role_from_token(token: str = Depends(oauth2_scheme)) -> str:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+    try:
+        if token is None:
+            return None
+
+        payload = jwt.decode(token, os.environ.get("API_KEY"), algorithms=["HS256"])
+
+        if payload.get("role") is None:
+            raise credentials_exception
+
+        return payload.get("role")
 
     except JWTError as e:
         print(f"JWT Error Occurred, {e}")

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,7 +20,7 @@
         <div style="text-align:center;">
             &copy; 2024
             <a href="/" class="home"><img id="home" src="{{ url_for('static', path='/home.png') }}"></a>
-            Version: 1.7.8
+            Version: 1.8.0
         </div>
     </nav>
 

--- a/templates/login.html
+++ b/templates/login.html
@@ -34,7 +34,7 @@
             </div>
           </div>
         </a>
-        {% if username == 'jyablonski' %}
+        {% if role == 'Admin' %}
         <a href="/admin">
           <div class="card">
             <div class="card-container">

--- a/tests/integration/admin_tasks_page_test.py
+++ b/tests/integration/admin_tasks_page_test.py
@@ -11,7 +11,7 @@ def test_admin_task_post_no_auth(client_fixture):
 
 
 def test_admin_tasks_post_wrong_auth(client_fixture):
-    username = "test1"
+    username = "test"
 
     login_response = client_fixture.post(  # noqa: F841
         "/login",

--- a/tests/integration/admin_test.py
+++ b/tests/integration/admin_test.py
@@ -9,7 +9,7 @@ def test_admin_get_no_auth(client_fixture):
 
 
 def test_admin_get_wrong_auth(client_fixture):
-    username = "test1"
+    username = "test"
 
     login_response = client_fixture.post(  # noqa: F841
         "/login",

--- a/tests/integration/feature_flags_test.py
+++ b/tests/integration/feature_flags_test.py
@@ -12,7 +12,7 @@ def test_feature_flags_get_no_auth(client_fixture):
 
 
 def test_feature_flags_get_wrong_auth(client_fixture):
-    username = "test1"
+    username = "test"
 
     login_response = client_fixture.post(  # noqa: F841
         "/login",
@@ -46,7 +46,7 @@ def test_feature_flags_get_success(client_fixture):
 
 
 def test_feature_flags_create_wrong_auth(client_fixture):
-    username = "test1"
+    username = "test"
 
     login_response = client_fixture.post(  # noqa: F841
         "/login",

--- a/tests/integration/incidents_test.py
+++ b/tests/integration/incidents_test.py
@@ -12,7 +12,7 @@ def test_incidents_get_no_auth(client_fixture):
 
 
 def test_incidents_get_wrong_auth(client_fixture):
-    username = "test1"
+    username = "test"
 
     login_response = client_fixture.post(  # noqa: F841
         "/login",
@@ -46,7 +46,7 @@ def test_incidents_get_success(client_fixture):
 
 
 def test_incidents_create_wrong_auth(client_fixture):
-    username = "test1"
+    username = "test"
 
     login_response = client_fixture.post(  # noqa: F841
         "/login",

--- a/tests/integration/login_test.py
+++ b/tests/integration/login_test.py
@@ -11,6 +11,7 @@ def test_login_get(client_fixture):
 
     assert f"Welcome <b>{username}" in response.text
     assert response.status_code == 200
+    assert "access_token" in client_fixture.cookies
 
 
 def test_login_fail(client_fixture):
@@ -26,6 +27,7 @@ def test_login_fail(client_fixture):
 
     assert response.status_code == 200
     assert "Incorrect Username or Password" in response.text
+    assert "access_token" not in client_fixture.cookies
 
 
 def test_login_get_with_no_token(client_fixture):
@@ -51,6 +53,7 @@ def test_login_get_with_token(client_fixture):
     assert response.status_code == 200
     assert f"Welcome <b>{username}" in get_response.text
     assert get_response.status_code == 200
+    assert "access_token" in client_fixture.cookies
 
 
 def test_create_user_get(client_fixture):

--- a/tests/integration/logout_test.py
+++ b/tests/integration/logout_test.py
@@ -11,12 +11,14 @@ def test_logout(client_fixture):
 
     assert f"Welcome <b>{username}" in response.text
     assert response.status_code == 200
+    assert "access_token" in client_fixture.cookies
 
     logout_response = client_fixture.post(
         "/logout",
         follow_redirects=False,
     )
     assert logout_response.status_code == 302
+    assert "access_token" not in client_fixture.cookies
 
 
 def test_logout_no_user(client_fixture):
@@ -25,3 +27,4 @@ def test_logout_no_user(client_fixture):
     )
     assert response.status_code == 200
     assert "User Login" in response.text
+    assert "access_token" not in client_fixture.cookies

--- a/tests/unit/jwt_access_token_test.py
+++ b/tests/unit/jwt_access_token_test.py
@@ -3,7 +3,7 @@ import os
 
 from jose import jwt
 
-from src.security import create_access_token
+from src.security import create_access_token, get_current_creds_from_token
 
 # this is base64 encoded
 # eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXSD3.eyJzdWIiOiJqeWFibG9uc2tpIiwiZXhwIjoxNjg2ATUyMTIwfQ.7S3zquBmNJD5s2d7i3_zbxjJFLa79HVjx75GFh9R92s
@@ -34,8 +34,8 @@ def test_decode_access_token():
         data={"sub": username, "role": role}, expires=access_token_expires
     )
 
-    payload = jwt.decode(access_token, os.environ.get("API_KEY"), algorithms=["HS256"])
-    jwt_username = payload["sub"]
+    payload = get_current_creds_from_token(token=access_token)
+    jwt_username = payload["username"]
     jwt_role = payload["role"]
     jwt_expiration = payload["exp"]
 

--- a/tests/unit/jwt_access_token_test.py
+++ b/tests/unit/jwt_access_token_test.py
@@ -1,7 +1,4 @@
 from datetime import datetime, timedelta, timezone
-import os
-
-from jose import jwt
 
 from src.security import create_access_token, get_current_creds_from_token
 

--- a/tests/unit/jwt_access_token_test.py
+++ b/tests/unit/jwt_access_token_test.py
@@ -27,14 +27,16 @@ def test_generate_access_token():
 
 def test_decode_access_token():
     username = "big_stupid_jwt_user"
+    role = "Consumer"
     access_token_expires = datetime.now(timezone.utc) + timedelta(days=30)
 
     access_token = create_access_token(
-        data={"sub": username}, expires=access_token_expires
+        data={"sub": username, "role": role}, expires=access_token_expires
     )
 
     payload = jwt.decode(access_token, os.environ.get("API_KEY"), algorithms=["HS256"])
     jwt_username = payload["sub"]
+    jwt_role = payload["role"]
     jwt_expiration = payload["exp"]
 
     jwt_expiration = datetime.fromtimestamp(jwt_expiration)
@@ -42,5 +44,6 @@ def test_decode_access_token():
     # asserting that the username is the same, and that the jwt token lasts
     # longer than 30 days
     assert jwt_username == username
+    assert jwt_role == role
     assert (datetime.now() + timedelta(days=31)) > jwt_expiration
     assert (datetime.now() + timedelta(days=29)) < jwt_expiration

--- a/tests/unit/jwt_access_token_test.py
+++ b/tests/unit/jwt_access_token_test.py
@@ -6,7 +6,7 @@ from src.security import create_access_token, get_current_creds_from_token
 # eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXSD3.eyJzdWIiOiJqeWFibG9uc2tpIiwiZXhwIjoxNjg2ATUyMTIwfQ.7S3zquBmNJD5s2d7i3_zbxjJFLa79HVjx75GFh9R92s
 
 # then when u decode it, this is what's inside:
-# {'sub': 'jyablonski', 'exp': 1686152120}
+# {'sub': 'jyablonski', 'role': 'Admin', 'exp': 1686152120}
 
 
 def test_generate_access_token():


### PR DESCRIPTION
### Description
Updated Admin Permissions

## Added
- `role` Column in the Users Table to handle new Permissions Workflow
- `get_current_creds_from_token` which is almost a copy of `get_current_user_from_token` except it returns a dictionary of values from the JWT Token instead of just the `username` string

## Updated
- Permissions for various endpoints now checks for Admin Users instead of just `user = 'jyablonski'` checks
- JWT Token now includes `role` as well as the Username to avoid another Database Lookup when an endpoint requires a Role Check for Authentication
- Various Tests to also check for `access_token` in the Cookies after operations like Logging In
- Various Tests to use `test` user instead of `test1` user which is an Admin User for Local Development now

## Deleted
- `get_current_user_from_token` Function